### PR TITLE
Add minimal Level 1 shipment processing

### DIFF
--- a/src/main/java/lt/bananull/whse/Main.java
+++ b/src/main/java/lt/bananull/whse/Main.java
@@ -1,5 +1,10 @@
 package lt.bananull.whse;
 
+import lt.bananull.whse.dto.dataset.BinDto;
+import lt.bananull.whse.dto.dataset.GridDto;
+import lt.bananull.whse.dto.dataset.PortDto;
+import lt.bananull.whse.dto.dataset.ShipmentDto;
+import lt.bananull.whse.dto.dataset.ShiftDto;
 import lt.bananull.whse.load.DataLoader;
 import lt.bananull.whse.load.SimulationState;
 import lt.bananull.whse.sim.BasicShipmentProcessor;
@@ -30,6 +35,50 @@ public class Main {
         System.out.println("Shipments:  " + state.shipments().size());
         System.out.println();
 
+        System.out.println("=== BINS ===");
+        for (BinDto bin : state.bins()) {
+            System.out.println("Bin ID: " + bin.id()
+                    + ", grid: " + bin.currentGridLocation());
+            bin.itemsInBin().forEach((ean, itemDto) ->
+                    System.out.println("  Item " + ean
+                            + " -> qty=" + itemDto.quantity())
+            );
+            System.out.println();
+        }
+
+        System.out.println("=== GRIDS ===");
+        for (GridDto grid : state.grids()) {
+            System.out.println("Grid ID: " + grid.id());
+
+            if (grid.shifts() != null) {
+                for (ShiftDto shift : grid.shifts()) {
+                    System.out.println("  Shift: " + shift.start()
+                            + " - " + shift.end());
+
+                    if (shift.portConfig() != null) {
+                        System.out.println("    Ports:");
+                        for (PortDto port : shift.portConfig()) {
+                            System.out.println("      Port ID: " + port.id()
+                                    + ", flags=" + port.handlingFlags());
+                        }
+                    }
+                }
+            }
+
+            System.out.println();
+        }
+
+        System.out.println("=== SHIPMENTS ===");
+        for (ShipmentDto shipment : state.shipments()) {
+            System.out.println("Shipment ID:   " + shipment.id());
+            System.out.println("Shipment date: " + shipment.shipmentDate());
+            System.out.println("Items:");
+            shipment.items().forEach((ean, qty) ->
+                    System.out.println("  " + ean + " -> " + qty)
+            );
+            System.out.println();
+        }
+
         BasicShipmentProcessor processor = new BasicShipmentProcessor();
         BasicShipmentProcessor.Result result = processor.process(state);
 
@@ -37,7 +86,6 @@ public class Main {
         System.out.println("Packed shipments:            " + result.packedShipments());
         System.out.println("Failed/unprocessed shipments:" + result.failedShipments());
         System.out.println();
-
         System.out.println("Remaining bin quantities:");
         for (Map.Entry<String, Map<String, Integer>> bin : result.remainingBinQuantities().entrySet()) {
             System.out.println("  Bin " + bin.getKey() + ":");

--- a/src/main/java/lt/bananull/whse/Main.java
+++ b/src/main/java/lt/bananull/whse/Main.java
@@ -1,14 +1,11 @@
 package lt.bananull.whse;
 
-import lt.bananull.whse.dto.dataset.BinDto;
-import lt.bananull.whse.dto.dataset.GridDto;
-import lt.bananull.whse.dto.dataset.ShipmentDto;
-import lt.bananull.whse.dto.dataset.PortDto;
-import lt.bananull.whse.dto.dataset.ShiftDto;
 import lt.bananull.whse.load.DataLoader;
 import lt.bananull.whse.load.SimulationState;
+import lt.bananull.whse.sim.BasicShipmentProcessor;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 public class Main {
     public static void main(String[] args) {
@@ -33,47 +30,20 @@ public class Main {
         System.out.println("Shipments:  " + state.shipments().size());
         System.out.println();
 
-        System.out.println("=== BINS ===");
-        for (BinDto bin : state.bins()) {
-            System.out.println("Bin ID: " + bin.id()
-                    + ", grid: " + bin.currentGridLocation());
-            bin.itemsInBin().forEach((ean, itemDto) ->
-                    System.out.println("  Item " + ean
-                            + " -> qty=" + itemDto.quantity())
-            );
-            System.out.println();
-        }
+        BasicShipmentProcessor processor = new BasicShipmentProcessor();
+        BasicShipmentProcessor.Result result = processor.process(state);
 
-        System.out.println("=== GRIDS ===");
-        for (GridDto grid : state.grids()) {
-            System.out.println("Grid ID: " + grid.id());
+        System.out.println("=== LEVEL 1 PROCESSING RESULT ===");
+        System.out.println("Packed shipments:            " + result.packedShipments());
+        System.out.println("Failed/unprocessed shipments:" + result.failedShipments());
+        System.out.println();
 
-            if (grid.shifts() != null) {
-                for (ShiftDto shift : grid.shifts()) {
-                    System.out.println("  Shift: " + shift.start()
-                            + " - " + shift.end());
-
-                    if (shift.portConfig() != null) {
-                        System.out.println("    Ports:");
-                        for (PortDto port : shift.portConfig()) {
-                            System.out.println("      Port ID: " + port.id()
-                                    + ", flags=" + port.handlingFlags());
-                        }
-                    }
-                }
+        System.out.println("Remaining bin quantities:");
+        for (Map.Entry<String, Map<String, Integer>> bin : result.remainingBinQuantities().entrySet()) {
+            System.out.println("  Bin " + bin.getKey() + ":");
+            for (Map.Entry<String, Integer> item : bin.getValue().entrySet()) {
+                System.out.println("    " + item.getKey() + " -> qty=" + item.getValue());
             }
-
-            System.out.println();
-        }
-
-        System.out.println("=== SHIPMENTS ===");
-        for (ShipmentDto shipment : state.shipments()) {
-            System.out.println("Shipment ID:   " + shipment.id());
-            System.out.println("Shipment date: " + shipment.shipmentDate());
-            System.out.println("Items:");
-            shipment.items().forEach((ean, qty) ->
-                    System.out.println("  " + ean + " -> " + qty)
-            );
             System.out.println();
         }
     }

--- a/src/main/java/lt/bananull/whse/sim/BasicShipmentProcessor.java
+++ b/src/main/java/lt/bananull/whse/sim/BasicShipmentProcessor.java
@@ -1,0 +1,64 @@
+package lt.bananull.whse.sim;
+
+import lt.bananull.whse.dto.dataset.BinDto;
+import lt.bananull.whse.dto.dataset.BinItemDto;
+import lt.bananull.whse.dto.dataset.ShipmentDto;
+import lt.bananull.whse.load.SimulationState;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class BasicShipmentProcessor {
+
+    public Result process(SimulationState state) {
+        Map<String, Map<String, Integer>> remainingByBin = buildMutableStock(state);
+
+        int packedCount = 0;
+        int failedCount = 0;
+
+        for (ShipmentDto shipment : state.shipments()) {
+            String matchingBinId = findMatchingBin(remainingByBin, shipment);
+            if (matchingBinId == null) {
+                failedCount++;
+                continue;
+            }
+
+            Map<String, Integer> binStock = remainingByBin.get(matchingBinId);
+            shipment.items().forEach((ean, qty) ->
+                    binStock.put(ean, binStock.get(ean) - qty));
+            packedCount++;
+        }
+
+        return new Result(packedCount, failedCount, remainingByBin);
+    }
+
+    private static Map<String, Map<String, Integer>> buildMutableStock(SimulationState state) {
+        Map<String, Map<String, Integer>> remainingByBin = new LinkedHashMap<>();
+        for (BinDto bin : state.bins()) {
+            Map<String, Integer> stock = new LinkedHashMap<>();
+            for (Map.Entry<String, BinItemDto> item : bin.itemsInBin().entrySet()) {
+                stock.put(item.getKey(), item.getValue().quantity());
+            }
+            remainingByBin.put(bin.id(), stock);
+        }
+        return remainingByBin;
+    }
+
+    private static String findMatchingBin(Map<String, Map<String, Integer>> remainingByBin, ShipmentDto shipment) {
+        for (Map.Entry<String, Map<String, Integer>> entry : remainingByBin.entrySet()) {
+            Map<String, Integer> stock = entry.getValue();
+            boolean matches = shipment.items().entrySet().stream()
+                    .allMatch(required -> stock.getOrDefault(required.getKey(), 0) >= required.getValue());
+            if (matches) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    public record Result(
+            int packedShipments,
+            int failedShipments,
+            Map<String, Map<String, Integer>> remainingBinQuantities
+    ) {}
+}


### PR DESCRIPTION
Closes #12

Adds a minimal Level 1 shipment processing step after data loading:
- finds a matching bin
- decrements quantity
- counts packed/failed shipments
- prints a short summary

Kept intentionally small and review-friendly.
No router or event logic included yet.